### PR TITLE
fixes HomeScreen animation when returning from StoryScreen 

### DIFF
--- a/src/screens/Home.tsx
+++ b/src/screens/Home.tsx
@@ -121,7 +121,10 @@ const HomeScreen: React.FC<{
   const onPress = useCallback(() => {
     setIsChangingPage(true);
 
-    setTimeout(() => navigation.navigate("Genres"), 2000);
+    setTimeout(() => {
+      setIsChangingPage(false);
+      navigation.navigate("Genres");
+    }, 2000);
   }, []);
 
   return (


### PR DESCRIPTION
### What changes have you made?

- Since the HomeScreen never "unmounts" we need to reset the `isChangingPage` boolean once the page has changed

### Which issue(s) does this PR fix?

Fixes #13 

### How to test

- Home screen, click start your story
- choose genre
- press "its bedtime" on the StoryScreen
- should take you back to the HomeScreen where the animations run again when you click "start your story" again